### PR TITLE
Reuse settings StoragePaths in storage module

### DIFF
--- a/graph/storage.py
+++ b/graph/storage.py
@@ -5,11 +5,11 @@ import sqlite3
 import json, hashlib
 from typing import Dict, Any, Iterable, List, Optional, Sequence, Tuple
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import replace
 from dotenv import load_dotenv
 from openai import OpenAI, AzureOpenAI
 import chromadb
-from settings import settings
+from settings import settings, StoragePaths as SettingsStoragePaths
 
 
 
@@ -1020,14 +1020,8 @@ class RelationVectors(_ChromaBase):
 # Unified Storage Facade
 # ---------------------------
 
-@dataclass
-class StoragePaths:
-    documents_db: str = settings.storage.documents_db
-    chunks_db: str = settings.storage.chunks_db
-    graph_db: str = settings.storage.graph_db
-    chroma_chunks: str = settings.storage.chroma_chunks
-    chroma_entities: str = settings.storage.chroma_entities
-    chroma_relations: str = settings.storage.chroma_relations
+# Re-export the unified StoragePaths dataclass from graph.settings for compatibility.
+StoragePaths = SettingsStoragePaths
 
 
 class Storage:
@@ -1044,7 +1038,8 @@ class Storage:
     """
 
     def __init__(self, paths: Optional[StoragePaths] = None, embedder: Optional[Embedder] = None):
-        paths = paths or StoragePaths()
+        if paths is None:
+            paths = replace(settings.storage)
 
         # Schema DBs
         self.documents = DocumentsDB(paths.documents_db)


### PR DESCRIPTION
## Summary
- reuse the StoragePaths dataclass from `graph.settings` within the storage facade
- default `Storage` initialization to a copy of the global `settings.storage` paths

## Testing
- `.venv/bin/python -m pytest test/test_storage_full.py` *(fails: No module named pytest in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc1e943ac832386df30744c00f061