### PR TITLE
Remove unused delimiter variable in ensure_edge_endpoints

### DIFF
--- a/graph/ingestion.py
+++ b/graph/ingestion.py
@@ -283,8 +283,6 @@ def ensure_edge_endpoints(storage: Storage, edges: List[Dict[str, Any]]) -> List
            - If exactly 1 typed node exists -> do nothing (unambiguous)
     Returns a list of node dicts that were *created* (so caller can vectorize them).
     """
-    delim = settings.ingestion.delimiter
-
     # 1) Collect per-name type hints coming from relationships (if extractor provided them).
     hinted: Dict[str, set] = {}
     for e in edges:


### PR DESCRIPTION
## Summary
- remove the unused delimiter variable from `ensure_edge_endpoints`

## Testing
- pytest test *(fails: ModuleNotFoundError: No module named 'chromadb')*

------
https://chatgpt.com/codex/tasks/task_e_68cfc1bb616c83239552a86ffc5383c5