### PR TITLE
Remove unused FileStats dataclass

### DIFF
--- a/graph/ingestion.py
+++ b/graph/ingestion.py
@@ -12,15 +12,9 @@ from extractor import extract_from_chunks
 from llm import llm_summarize_text
 from settings import settings
 import os
-from dataclasses import dataclass
 import hashlib
 
 # Helpers -------------------------------------------
-
-@dataclass(frozen=True)
-class FileStats:
-    size: int
-    mtime: float
 
 def normalize_metadata(meta: Dict[str, Any]) -> Dict[str, Any]:
     # Lower-case keys, unify language key


### PR DESCRIPTION
## Summary
- delete the unused FileStats dataclass from the ingestion module
- drop the unnecessary dataclasses import to keep the module clean

## Testing
- python -m py_compile graph/ingestion.py

------
https://chatgpt.com/codex/tasks/task_e_68cfcbcdaee88323bb6f5ce3dbfee622