### PR TITLE
Fix Chroma query keyword usage

### DIFF
--- a/graph/storage.py
+++ b/graph/storage.py
@@ -836,7 +836,7 @@ class _ChromaBase:
     def _query(self, texts: List[str], n_results: int, where: Optional[Dict[str, Any]] = None,
                where_document: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
         embeddings = self.embedder.embed_texts(texts)
-        res = self.col.query(embeddings=embeddings, n_results=n_results, where=where,
+        res = self.col.query(query_embeddings=embeddings, n_results=n_results, where=where,
                              where_document=where_document, include=["documents", "metadatas", "distances"])
         return self.to_list(res)
 


### PR DESCRIPTION
## Summary
- update the Chroma query helper to pass embeddings via the `query_embeddings` keyword expected by the latest chromadb client

## Testing
- python - <<'PY'
import types, sys

module = types.ModuleType("settings")

class _Provider:
    provider = "openai"
    openai_embeddings_model = "test-emb"
    openai_llm_model = "test-llm"
    openai_base_url = None
    openai_api_key = "test-key"
    azure_embeddings_deployment = ""
    azure_llm_deployment = ""
    azure_endpoint = ""
    azure_api_version = ""

class _Embeddings:
    batch_size = 64

class _StoragePaths:
    documents_db = ""
    chunks_db = ""
    graph_db = ""
    chroma_chunks = ""
    chroma_entities = ""
    chroma_relations = ""

module.settings = types.SimpleNamespace(
    provider=_Provider(),
    embeddings=_Embeddings(),
    storage=_StoragePaths(),
)

class StoragePaths:
    def __init__(self, **kwargs):
        for key, value in kwargs.items():
            setattr(self, key, value)

module.StoragePaths = StoragePaths
sys.modules['settings'] = module

from graph.storage import _ChromaBase

class DummyEmbedder:
    def embed_texts(self, texts):
        return [[0.0] * 3 for _ in texts]

class DummyCol:
    def __init__(self):
        self.called_kwargs = None

    def query(self, *, query_embeddings, n_results, where=None, where_document=None, include=None):
        self.called_kwargs = {
            "query_embeddings": query_embeddings,
            "n_results": n_results,
            "where": where,
            "where_document": where_document,
            "include": include,
        }
        return {}

dummy = object.__new__(_ChromaBase)
dummy.embedder = DummyEmbedder()
dummy.col = DummyCol()

result = _ChromaBase._query(dummy, ["hello"], 3)
assert result == []
assert dummy.col.called_kwargs["query_embeddings"] == [[0.0, 0.0, 0.0]]
print("query executed with query_embeddings keyword successfully")
PY

------
https://chatgpt.com/codex/tasks/task_e_68d1b2f388bc83239ccdc4cfd09a71a2